### PR TITLE
LobbiesByStatus (Katrin)

### DIFF
--- a/app/src/main/java/com/example/mankomania/api/AuthAPI.java
+++ b/app/src/main/java/com/example/mankomania/api/AuthAPI.java
@@ -14,7 +14,7 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 
-public class Auth {
+public class AuthAPI {
     private static String token;
 
     private static String message;

--- a/app/src/main/java/com/example/mankomania/api/Lobby.java
+++ b/app/src/main/java/com/example/mankomania/api/Lobby.java
@@ -1,0 +1,69 @@
+package com.example.mankomania.api;
+
+import java.util.UUID;
+
+public class Lobby {
+    private UUID id;
+    private String name;
+    private String password;
+    private boolean isPrivate;
+    private int maxPlayers;
+    private Status status;
+
+    public Lobby(UUID id, String name, String password, boolean isPrivate, int maxPlayers, Status status) {
+        this.id = id;
+        this.name = name;
+        this.password = password;
+        this.isPrivate = isPrivate;
+        this.maxPlayers = maxPlayers;
+        this.status = status;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public boolean isPrivate() {
+        return isPrivate;
+    }
+
+    public void setPrivate(boolean aPrivate) {
+        isPrivate = aPrivate;
+    }
+
+    public int getMaxPlayers() {
+        return maxPlayers;
+    }
+
+    public void setMaxPlayers(int maxPlayers) {
+        this.maxPlayers = maxPlayers;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+}

--- a/app/src/main/java/com/example/mankomania/api/Lobby.java
+++ b/app/src/main/java/com/example/mankomania/api/Lobby.java
@@ -38,7 +38,7 @@ public class Lobby {
     public static void getLobbies(String token, final GetLobbiesCallback callback) {
         Request request = new Request.Builder()
                 .url(HttpClient.getServer() + ":" + HttpClient.getPort() + "/api/lobby/getAll")
-                .header("Authorisation", token)
+                .header("Authorization", token)
                 .build();
 
         HttpClient.getHttpClient().newCall(request).enqueue(new Callback() {

--- a/app/src/main/java/com/example/mankomania/api/Lobby.java
+++ b/app/src/main/java/com/example/mankomania/api/Lobby.java
@@ -1,5 +1,7 @@
 package com.example.mankomania.api;
 
+import androidx.annotation.NonNull;
+
 import java.util.UUID;
 
 public class Lobby {
@@ -65,5 +67,19 @@ public class Lobby {
 
     public void setStatus(Status status) {
         this.status = status;
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        String string = "";
+        string += "ID: " + this.id;
+        string += "\nName: " + this.name;
+        string += "\nPassword: " + this.password;
+        string += "\nPrivate: " + this.isPrivate;
+        string += "\nMax. Players: " + this.maxPlayers;
+        string += "\nStatus: " + this.status;
+
+        return string;
     }
 }

--- a/app/src/main/java/com/example/mankomania/api/Lobby.java
+++ b/app/src/main/java/com/example/mankomania/api/Lobby.java
@@ -65,7 +65,7 @@ public class Lobby {
                         callback.onGetLobbiesFailure("Fehler beim Lesen der Response!");
                     }
                 } else {
-                    callback.onGetLobbiesFailure("Fehler!");
+                    callback.onGetLobbiesFailure(response.message());
                 }
             }
         });
@@ -117,7 +117,7 @@ public class Lobby {
                         callback.onAddLobbyFailure("Fehler beim Lesen der Response!");
                     }
                 } else {
-                    callback.onAddLobbyFailure("Fehler!");
+                    callback.onAddLobbyFailure(response.message());
                 }
             }
         });

--- a/app/src/main/java/com/example/mankomania/api/Lobby.java
+++ b/app/src/main/java/com/example/mankomania/api/Lobby.java
@@ -1,5 +1,7 @@
 package com.example.mankomania.api;
 
+import static org.json.JSONObject.NULL;
+
 import androidx.annotation.NonNull;
 
 import org.json.JSONArray;
@@ -78,7 +80,15 @@ public class Lobby {
         JSONObject jsonRequest = new JSONObject();
         try {
             jsonRequest.put("name", name);
-            jsonRequest.put("password", password);
+
+            // JSONObjects need special NULL Value from library instead of standard null value
+            // this if-else is needed to pass null value into DB for no-password-lobbies
+            if(password == null) {
+                jsonRequest.put("password", NULL);
+            } else {
+                jsonRequest.put("password", password);
+            }
+
             jsonRequest.put("isPrivate", isPrivate);
             jsonRequest.put("maxPlayers", maxPlayer);
             jsonRequest.put("status", status);

--- a/app/src/main/java/com/example/mankomania/api/Lobby.java
+++ b/app/src/main/java/com/example/mankomania/api/Lobby.java
@@ -21,54 +21,6 @@ public class Lobby {
         this.status = status;
     }
 
-    public UUID getId() {
-        return id;
-    }
-
-    public void setId(UUID id) {
-        this.id = id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
-    }
-
-    public boolean isPrivate() {
-        return isPrivate;
-    }
-
-    public void setPrivate(boolean aPrivate) {
-        isPrivate = aPrivate;
-    }
-
-    public int getMaxPlayers() {
-        return maxPlayers;
-    }
-
-    public void setMaxPlayers(int maxPlayers) {
-        this.maxPlayers = maxPlayers;
-    }
-
-    public Status getStatus() {
-        return status;
-    }
-
-    public void setStatus(Status status) {
-        this.status = status;
-    }
-
     @NonNull
     @Override
     public String toString() {

--- a/app/src/main/java/com/example/mankomania/api/LobbyAPI.java
+++ b/app/src/main/java/com/example/mankomania/api/LobbyAPI.java
@@ -24,6 +24,7 @@ import okhttp3.Response;
 
 public class LobbyAPI {
     private static List<Lobby> allLobbies;
+    private static List<Lobby> openLobbies;
     private static String[] lobbyNames;
     private static String message;
 
@@ -72,7 +73,7 @@ public class LobbyAPI {
 
                         for(int i = 0; i < responseArray.length(); i++) {
                             JSONObject jsonLobby = responseArray.getJSONObject(i);
-                            addLobbyToAllLobbiesList(jsonLobby);
+                            addLobbyToList(jsonLobby, allLobbies);
                             lobbyNames[i] = jsonLobby.getString("name");
                         }
 
@@ -111,12 +112,22 @@ public class LobbyAPI {
 
                     try {
                         JSONArray responseArray = new JSONArray(responseBody);
+                        openLobbies = new ArrayList<>();
                         lobbyNames = new String[responseArray.length()];
 
                         for(int i = 0; i < responseArray.length(); i++) {
                             JSONObject jsonLobby = responseArray.getJSONObject(i);
+                            if(status == Status.open) {
+                                addLobbyToList(jsonLobby, openLobbies);
+                            }
                             lobbyNames[i] = jsonLobby.getString("name");
                         }
+
+                        // logging...
+                        for(Lobby l : openLobbies) {
+                            Log.v("Katrin", l.toString());
+                        }
+
                         callback.onGetLobbiesByStatusSuccess(lobbyNames);
                     } catch (JSONException e) {
                         callback.onGetLobbiesByStatusFailure("Fehler beim Lesen der Response!");
@@ -192,7 +203,7 @@ public class LobbyAPI {
      * this method takes a JSONObject that represents a lobby, creates an equivalent Lobby object
      * and adds it to the lobbies list
      */
-    private static void addLobbyToAllLobbiesList(JSONObject jsonLobby) throws JSONException {
+    private static void addLobbyToList(JSONObject jsonLobby, List<Lobby> list) throws JSONException {
         UUID id = UUID.fromString(jsonLobby.getString("id"));
         String name = jsonLobby.getString("name");
         String password = jsonLobby.getString("password");
@@ -226,7 +237,7 @@ public class LobbyAPI {
         }
 
         Lobby lobby = new Lobby(id, name, password, isPrivate, maxPlayers, status);
-        allLobbies.add(lobby);
+        list.add(lobby);
     }
 
 }

--- a/app/src/main/java/com/example/mankomania/api/LobbyAPI.java
+++ b/app/src/main/java/com/example/mankomania/api/LobbyAPI.java
@@ -25,7 +25,8 @@ import okhttp3.Response;
 public class LobbyAPI {
     private static List<Lobby> allLobbies;
     private static List<Lobby> openLobbies;
-    private static String[] lobbyNames;
+    private static String[] allLobbiesDisplayStrings;
+    private static String[] openLobbiesDisplayStrings;
     private static String message;
 
     // interface to notify whether login is successful or not
@@ -69,12 +70,25 @@ public class LobbyAPI {
                     try {
                         JSONArray responseArray = new JSONArray(responseBody);
                         allLobbies = new ArrayList<>();
-                        lobbyNames = new String[responseArray.length()];
+                        allLobbiesDisplayStrings = new String[responseArray.length()];
 
                         for(int i = 0; i < responseArray.length(); i++) {
                             JSONObject jsonLobby = responseArray.getJSONObject(i);
                             addLobbyToList(jsonLobby, allLobbies);
-                            lobbyNames[i] = jsonLobby.getString("name");
+
+                            // TODO: replace x with actual value of players in lobby
+                            // TODO: find a better way to make it actually look pretty (sprint 3?)
+                            // generate string as display for GameScore.java
+                            allLobbiesDisplayStrings[i] = "";
+                            if(jsonLobby.getBoolean("isprivate")) {
+                                allLobbiesDisplayStrings[i] += "P";
+                            } else {
+                                allLobbiesDisplayStrings[i] += "O";
+                            }
+                            allLobbiesDisplayStrings[i] += " | ";
+                            allLobbiesDisplayStrings[i] += " x/" + jsonLobby.getInt("maxplayers");
+                            allLobbiesDisplayStrings[i] += " | ";
+                            allLobbiesDisplayStrings[i] += jsonLobby.getString("name");
                         }
 
                         // logging...
@@ -82,7 +96,7 @@ public class LobbyAPI {
                             Log.v("Katrin", l.toString());
                         }
 
-                        callback.onGetLobbiesSuccess(lobbyNames);
+                        callback.onGetLobbiesSuccess(allLobbiesDisplayStrings);
                     } catch (JSONException e) {
                         callback.onGetLobbiesFailure("Fehler beim Lesen der Response!");
                     }
@@ -113,14 +127,27 @@ public class LobbyAPI {
                     try {
                         JSONArray responseArray = new JSONArray(responseBody);
                         openLobbies = new ArrayList<>();
-                        lobbyNames = new String[responseArray.length()];
+                        openLobbiesDisplayStrings = new String[responseArray.length()];
 
                         for(int i = 0; i < responseArray.length(); i++) {
                             JSONObject jsonLobby = responseArray.getJSONObject(i);
                             if(status == Status.open) {
                                 addLobbyToList(jsonLobby, openLobbies);
+
+                                // TODO: replace x with actual value of players in lobby
+                                // TODO: find a better way to make it actually look pretty (sprint 3?)
+                                // generate string as display for GameScore.java
+                                openLobbiesDisplayStrings[i] = "";
+                                if(jsonLobby.getBoolean("isprivate")) {
+                                    openLobbiesDisplayStrings[i] += "P";
+                                } else {
+                                    openLobbiesDisplayStrings[i] += "O";
+                                }
+                                openLobbiesDisplayStrings[i] += " | ";
+                                openLobbiesDisplayStrings[i] += "x/" + jsonLobby.getInt("maxplayers");
+                                openLobbiesDisplayStrings[i] += " | ";
+                                openLobbiesDisplayStrings[i] += jsonLobby.getString("name");
                             }
-                            lobbyNames[i] = jsonLobby.getString("name");
                         }
 
                         // logging...
@@ -128,7 +155,7 @@ public class LobbyAPI {
                             Log.v("Katrin", l.toString());
                         }
 
-                        callback.onGetLobbiesByStatusSuccess(lobbyNames);
+                        callback.onGetLobbiesByStatusSuccess(openLobbiesDisplayStrings);
                     } catch (JSONException e) {
                         callback.onGetLobbiesByStatusFailure("Fehler beim Lesen der Response!");
                     }

--- a/app/src/main/java/com/example/mankomania/api/LobbyAPI.java
+++ b/app/src/main/java/com/example/mankomania/api/LobbyAPI.java
@@ -17,7 +17,7 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 
-public class Lobby {
+public class LobbyAPI {
     private static String[] lobbyNames;
     private static String message;
 

--- a/app/src/main/java/com/example/mankomania/api/Status.java
+++ b/app/src/main/java/com/example/mankomania/api/Status.java
@@ -1,9 +1,9 @@
 package com.example.mankomania.api;
 
 public enum Status {
-    OPEN,
-    STARTING,
-    INGAME,
-    FINISHED,
-    CLOSED
+    open,
+    starting,
+    inGame,
+    finished,
+    closed
 }

--- a/app/src/main/java/com/example/mankomania/screens/CreateNewLobby.java
+++ b/app/src/main/java/com/example/mankomania/screens/CreateNewLobby.java
@@ -4,7 +4,6 @@ package com.example.mankomania.screens;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.util.Log;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
@@ -19,10 +18,10 @@ import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 
 import com.example.mankomania.R;
-import com.example.mankomania.api.Lobby;
+import com.example.mankomania.api.LobbyAPI;
 import com.example.mankomania.api.Status;
 
-public class CreateNewLobby extends AppCompatActivity implements Lobby.AddLobbyCallback{
+public class CreateNewLobby extends AppCompatActivity implements LobbyAPI.AddLobbyCallback{
 
     EditText nameInput;
     SwitchCompat privateLobbySwitch;
@@ -85,7 +84,7 @@ public class CreateNewLobby extends AppCompatActivity implements Lobby.AddLobbyC
             SharedPreferences sharedPreferences = getSharedPreferences("MyPrefs", MODE_PRIVATE);
             String token = sharedPreferences.getString("token", null);
             // add lobby
-            Lobby.addLobby(token, lobbyName, lobbyPassword, isLobbyPrivate, maxPlayers, Status.open, CreateNewLobby.this);
+            LobbyAPI.addLobby(token, lobbyName, lobbyPassword, isLobbyPrivate, maxPlayers, Status.open, CreateNewLobby.this);
         });
     }
 

--- a/app/src/main/java/com/example/mankomania/screens/CreateNewLobby.java
+++ b/app/src/main/java/com/example/mankomania/screens/CreateNewLobby.java
@@ -4,6 +4,7 @@ package com.example.mankomania.screens;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.util.Log;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
@@ -84,7 +85,7 @@ public class CreateNewLobby extends AppCompatActivity implements Lobby.AddLobbyC
             SharedPreferences sharedPreferences = getSharedPreferences("MyPrefs", MODE_PRIVATE);
             String token = sharedPreferences.getString("token", null);
             // add lobby
-            Lobby.addLobby(token, lobbyName, lobbyPassword, isLobbyPrivate, maxPlayers, Status.OPEN, CreateNewLobby.this);
+            Lobby.addLobby(token, lobbyName, lobbyPassword, isLobbyPrivate, maxPlayers, Status.open, CreateNewLobby.this);
         });
     }
 

--- a/app/src/main/java/com/example/mankomania/screens/GameScore.java
+++ b/app/src/main/java/com/example/mankomania/screens/GameScore.java
@@ -40,7 +40,8 @@ public class GameScore extends AppCompatActivity implements LobbyAPI.GetLobbiesC
         SharedPreferences sharedPreferences = getSharedPreferences("MyPrefs", MODE_PRIVATE);
         String token = sharedPreferences.getString("token", null);
         // get Lobbies
-        LobbyAPI.getLobbiesByStatus(token, Status.open,GameScore.this);
+        // LobbyAPI.getLobbiesByStatus(token, Status.open, GameScore.this);
+        LobbyAPI.getLobbies(token, GameScore.this);
 
         Button resumeGame=findViewById(R.id.GameScore_ResumeGame);
         resumeGame.setOnClickListener(v -> {

--- a/app/src/main/java/com/example/mankomania/screens/GameScore.java
+++ b/app/src/main/java/com/example/mankomania/screens/GameScore.java
@@ -40,8 +40,8 @@ public class GameScore extends AppCompatActivity implements LobbyAPI.GetLobbiesC
         SharedPreferences sharedPreferences = getSharedPreferences("MyPrefs", MODE_PRIVATE);
         String token = sharedPreferences.getString("token", null);
         // get Lobbies
-        // LobbyAPI.getLobbiesByStatus(token, Status.open, GameScore.this);
-        LobbyAPI.getLobbies(token, GameScore.this);
+        LobbyAPI.getLobbiesByStatus(token, Status.open, GameScore.this);
+        // LobbyAPI.getLobbies(token, GameScore.this);
 
         Button resumeGame=findViewById(R.id.GameScore_ResumeGame);
         resumeGame.setOnClickListener(v -> {

--- a/app/src/main/java/com/example/mankomania/screens/GameScore.java
+++ b/app/src/main/java/com/example/mankomania/screens/GameScore.java
@@ -16,10 +16,10 @@ import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 
 import com.example.mankomania.R;
-import com.example.mankomania.api.Lobby;
+import com.example.mankomania.api.LobbyAPI;
 import com.example.mankomania.api.Status;
 
-public class GameScore extends AppCompatActivity implements Lobby.GetLobbiesCallback, Lobby.GetLobbiesByStatusCallback {
+public class GameScore extends AppCompatActivity implements LobbyAPI.GetLobbiesCallback, LobbyAPI.GetLobbiesByStatusCallback {
 
     private ListView listOfGames;
 
@@ -40,7 +40,7 @@ public class GameScore extends AppCompatActivity implements Lobby.GetLobbiesCall
         SharedPreferences sharedPreferences = getSharedPreferences("MyPrefs", MODE_PRIVATE);
         String token = sharedPreferences.getString("token", null);
         // get Lobbies
-        Lobby.getLobbiesByStatus(token, Status.open,GameScore.this);
+        LobbyAPI.getLobbiesByStatus(token, Status.open,GameScore.this);
 
         Button resumeGame=findViewById(R.id.GameScore_ResumeGame);
         resumeGame.setOnClickListener(v -> {

--- a/app/src/main/java/com/example/mankomania/screens/GameScore.java
+++ b/app/src/main/java/com/example/mankomania/screens/GameScore.java
@@ -41,7 +41,6 @@ public class GameScore extends AppCompatActivity implements LobbyAPI.GetLobbiesC
         String token = sharedPreferences.getString("token", null);
         // get Lobbies
         LobbyAPI.getLobbiesByStatus(token, Status.open, GameScore.this);
-        // LobbyAPI.getLobbies(token, GameScore.this);
 
         Button resumeGame=findViewById(R.id.GameScore_ResumeGame);
         resumeGame.setOnClickListener(v -> {
@@ -70,6 +69,10 @@ public class GameScore extends AppCompatActivity implements LobbyAPI.GetLobbiesC
 
     @Override
     public void onGetLobbiesSuccess(String[] lobbies) {
+        // will display the following rows:
+        // <P/O> | x/<m> | <name>
+        // P.. private lobby, O.. non-private lobby
+        // m.. max. players
         runOnUiThread(() -> {
             ArrayAdapter<String> adapter = new ArrayAdapter<>(GameScore.this,
                     android.R.layout.simple_list_item_single_choice, lobbies);
@@ -79,6 +82,10 @@ public class GameScore extends AppCompatActivity implements LobbyAPI.GetLobbiesC
 
     @Override
     public void onGetLobbiesByStatusSuccess(String[] lobbies) {
+        // will display the following rows:
+        // <P/O> | x/<m> | <name>
+        // P.. private lobby, O.. non-private lobby
+        // m.. max. players
         runOnUiThread(() -> {
             ArrayAdapter<String> adapter = new ArrayAdapter<>(GameScore.this,
                     android.R.layout.simple_list_item_single_choice, lobbies);

--- a/app/src/main/java/com/example/mankomania/screens/GameScore.java
+++ b/app/src/main/java/com/example/mankomania/screens/GameScore.java
@@ -17,8 +17,9 @@ import androidx.core.view.WindowInsetsCompat;
 
 import com.example.mankomania.R;
 import com.example.mankomania.api.Lobby;
+import com.example.mankomania.api.Status;
 
-public class GameScore extends AppCompatActivity implements Lobby.GetLobbiesCallback {
+public class GameScore extends AppCompatActivity implements Lobby.GetLobbiesCallback, Lobby.GetLobbiesByStatusCallback {
 
     private ListView listOfGames;
 
@@ -39,7 +40,7 @@ public class GameScore extends AppCompatActivity implements Lobby.GetLobbiesCall
         SharedPreferences sharedPreferences = getSharedPreferences("MyPrefs", MODE_PRIVATE);
         String token = sharedPreferences.getString("token", null);
         // get Lobbies
-        Lobby.getLobbies(token, GameScore.this);
+        Lobby.getLobbiesByStatus(token, Status.open,GameScore.this);
 
         Button resumeGame=findViewById(R.id.GameScore_ResumeGame);
         resumeGame.setOnClickListener(v -> {
@@ -73,5 +74,19 @@ public class GameScore extends AppCompatActivity implements Lobby.GetLobbiesCall
                     android.R.layout.simple_list_item_single_choice, lobbies);
             listOfGames.setAdapter(adapter);
         });
+    }
+
+    @Override
+    public void onGetLobbiesByStatusSuccess(String[] lobbies) {
+        runOnUiThread(() -> {
+            ArrayAdapter<String> adapter = new ArrayAdapter<>(GameScore.this,
+                    android.R.layout.simple_list_item_single_choice, lobbies);
+            listOfGames.setAdapter(adapter);
+        });
+    }
+
+    @Override
+    public void onGetLobbiesByStatusFailure(String errorMessage) {
+        runOnUiThread(() -> Toast.makeText(GameScore.this, "Fehler: " + errorMessage, Toast.LENGTH_SHORT).show());
     }
 }

--- a/app/src/main/java/com/example/mankomania/screens/MainActivityLogin.java
+++ b/app/src/main/java/com/example/mankomania/screens/MainActivityLogin.java
@@ -16,11 +16,11 @@ import android.widget.EditText;
 import android.widget.Toast;
 
 import com.example.mankomania.R;
-import com.example.mankomania.api.Auth;
+import com.example.mankomania.api.AuthAPI;
 
 import java.util.regex.Pattern;
 
-public class MainActivityLogin extends AppCompatActivity implements Auth.LoginCallback{
+public class MainActivityLogin extends AppCompatActivity implements AuthAPI.LoginCallback{
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -50,7 +50,7 @@ public class MainActivityLogin extends AppCompatActivity implements Auth.LoginCa
             if(isNoValidEmail(email)) {
                 emailInput.setError("E-Mail-Adresse ist ungültig.");
             } else {
-                Auth.login(email, password, MainActivityLogin.this);
+                AuthAPI.login(email, password, MainActivityLogin.this);
             }
         });
 

--- a/app/src/main/java/com/example/mankomania/screens/Register.java
+++ b/app/src/main/java/com/example/mankomania/screens/Register.java
@@ -14,9 +14,9 @@ import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 
 import com.example.mankomania.R;
-import com.example.mankomania.api.Auth;
+import com.example.mankomania.api.AuthAPI;
 
-public class Register extends AppCompatActivity implements Auth.RegisterCallback {
+public class Register extends AppCompatActivity implements AuthAPI.RegisterCallback {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -44,7 +44,7 @@ public class Register extends AppCompatActivity implements Auth.RegisterCallback
             } else if (password.length() <= 7) {
                 passwordInput.setError("Passwort muss >7 Zeichen lang sein.");
             } else {
-                Auth.register(email, password, Register.this);
+                AuthAPI.register(email, password, Register.this);
             }
         });
 


### PR DESCRIPTION
- Bugs gefixt: Lobbies können wieder angezeigt und erstellt werden
- API Endpoint (getByStatus: GET /api/lobby/getByStatus/<status>) umgesetzt: Lobbies können nun je nach Status abgefragt werden
- nur offene Lobbies werden nach Login angezeigt
- Darstellung der Lobbies geändert: zusätzliche Infos (private/public + max. Spieleranzahl) werden nun angezeigt